### PR TITLE
Add YamlDotNet dependency for msbuild analysis

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,13 @@ runs:
             includeAttribute.Value = $@"..\packages\$packageId.$packageVersion\analyzers\dotnet\SecurityCodeScan.VS2019.dll";
             analyzerNode.Attributes.Append(includeAttribute);
             itemGroupNode.AppendChild(analyzerNode);
+
+            XmlNode yamlAnalyzerNode = projXml.CreateNode(XmlNodeType.Element, "Analyzer", xmlNamespace);
+            XmlAttribute yamlIncludeAttribute = projXml.CreateAttribute("Include");
+            yamlIncludeAttribute.Value = $@"..\packages\$packageId.$packageVersion\analyzers\dotnet\YamlDotNet.dll";
+            yamlAnalyzerNode.Attributes.Append(yamlIncludeAttribute);
+            itemGroupNode.AppendChild(yamlAnalyzerNode);
+
             projXml.SelectSingleNode("//x:Project", nsmgr).AppendChild(itemGroupNode);
             projXml.Save(@"$project");
 


### PR DESCRIPTION
I had to manually add the YamlDotNet dependency in the xml project. I saw that when adding the Security Code Scan analyzer via nuget it creates automatically this dependency as an analyzer entry into the xml, so this fixes it.

Fixes #2 